### PR TITLE
feat: added caching

### DIFF
--- a/frontend/actions/logActions.ts
+++ b/frontend/actions/logActions.ts
@@ -1,4 +1,4 @@
-import { account, database } from "../app/appwrite";
+import { database } from "../app/appwrite";
 import { Permission, Role } from "appwrite";
 import {
   ADMISSION,
@@ -7,6 +7,7 @@ import {
 } from "../lib/appwriteDb";
 import type { CohortAccess } from "../lib/scheduleConfig";
 import { calculateAverages } from "../lib/gradeCalc";
+import { getAccountCached, getUserDocCached } from "../lib/appwriteCache";
 
 function userDocPermissions(userId: string) {
   return [
@@ -43,7 +44,7 @@ export interface StreamAdmissionInput {
 }
 
 export async function addLog(gradesInput: GradesInput) {
-    let loggedInUser = await account.get();
+    let loggedInUser = await getAccountCached();
     
     const averageGPA = calculateAverages(gradesInput).toFixed(2);
     
@@ -101,7 +102,7 @@ export async function addLog(gradesInput: GradesInput) {
 }
 
 export async function addStreamChoices(streamsInput: StreamsInput) {
-    let loggedInUser = await account.get();
+    let loggedInUser = await getAccountCached();
     
     const streamData = {
         streams: streamsInput.streams || "null",
@@ -145,7 +146,7 @@ export async function addStreamChoices(streamsInput: StreamsInput) {
 }
 
 export async function addStreamAdmission(streamAdmissionInput: StreamAdmissionInput) {
-    let loggedInUser = await account.get();
+    let loggedInUser = await getAccountCached();
     
     const streamAdmissionData = {
         streamIn: streamAdmissionInput.streamIn || "null",
@@ -234,15 +235,11 @@ export async function saveUserProfile(
   input: UserProfileInput,
   access: CohortAccess
 ) {
-  const loggedInUser = await account.get();
+  const loggedInUser = await getAccountCached();
 
   let existing: Record<string, unknown> | null = null;
   try {
-    existing = (await database.getDocument(
-      DATABASE_ID,
-      COLL_USERS,
-      loggedInUser.$id
-    )) as unknown as Record<string, unknown>;
+    existing = (await getUserDocCached(loggedInUser.$id)) as unknown as Record<string, unknown>;
   } catch {
     existing = null;
   }

--- a/frontend/app/authenticate/page.tsx
+++ b/frontend/app/authenticate/page.tsx
@@ -5,6 +5,7 @@ import { usePageTransition } from "@/components/TransitionProvider";
 import { account } from "../appwrite";
 import LogoutButton from "@/components/LogoutButton";
 import { useSectionTracking } from "@/hooks/useSectionTracking"
+import { getAccountCached } from "@/lib/appwriteCache";
 
 function AuthenticateContent() {
     const { navigate } = usePageTransition();
@@ -14,7 +15,7 @@ function AuthenticateContent() {
     useEffect(() => {
         async function initiatePage() {
             try {
-                let loggedInUser = await account.get();
+                let loggedInUser = await getAccountCached();
                 if (loggedInUser.emailVerification) {
                     navigate('/dashboard');
                 }

--- a/frontend/app/contact/page.tsx
+++ b/frontend/app/contact/page.tsx
@@ -11,6 +11,7 @@ import LogoutButton from "@/components/LogoutButton";
 import Footer from "@/components/Footer";
 import { useSectionTracking } from "@/hooks/useSectionTracking";
 import { account } from "../appwrite";
+import { getAccountCached } from "@/lib/appwriteCache";
 import { submitContactForm } from "@/lib/contactFunction";
 import { Loader2, Mail } from "lucide-react";
 
@@ -80,7 +81,7 @@ export default function ContactPage() {
     let cancelled = false;
     async function load() {
       try {
-        const user = await account.get();
+        const user = await getAccountCached();
         if (!user.emailVerification) {
           navigate("/authenticate");
           return;

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -18,23 +18,22 @@ import {
   AlertCircle,
   Sparkles,
 } from "lucide-react";
-import { account, database } from "../appwrite";
 import {
   usePageTransition,
   useTransitionPageReady,
 } from "@/components/TransitionProvider";
 import {
-  COLL_CUTOFFS,
-  COLL_MARKS,
-  COLL_USERS,
-  DATABASE_ID,
   academicYearFullLabel,
   academicYearShortLabel,
-  cutoffDocId,
-  markDocId,
-  queriesForCutoffYear,
   streamKeyFromCutoffDocId,
 } from "@/lib/appwriteDb";
+import {
+  getAccountCached,
+  getCutoffTotalCached,
+  getMarksTotalCached,
+  getUserDocCached,
+  listCutoffsForYearCached,
+} from "@/lib/appwriteCache";
 import {
   computeCurrentDashboardYear,
   getCompletedYears,
@@ -127,13 +126,21 @@ function LiveChoiceProjectionSection({
 
 function StatisticsDropdown({ year }: { year: number }) {
   const [isOpen, setIsOpen] = useState(false);
-  const archived = getCohortAccess(year).isArchived;
+  const [hasOpened, setHasOpened] = useState(false);
+
+  const toggleOpen = () => {
+    setIsOpen((prev) => {
+      const next = !prev;
+      if (next) setHasOpened(true);
+      return next;
+    });
+  };
 
   return (
     <div className="w-full bg-white/[0.03] backdrop-blur-sm border border-neutral-600/40 rounded-2xl overflow-hidden shadow-2xl">
       <button
         type="button"
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={toggleOpen}
         className="flex items-center justify-between w-full p-6 hover:bg-white/[0.04] transition-all duration-300 group"
       >
         <div className="flex items-center gap-3 flex-wrap">
@@ -154,17 +161,19 @@ function StatisticsDropdown({ year }: { year: number }) {
           isOpen ? "max-h-[5000px] opacity-100" : "max-h-0 opacity-0"
         }`}
       >
-        <div className="p-6 pt-2 space-y-8">
-          <div>
-            <HorizontalBarChart year={year} />
+        {hasOpened && (
+          <div className="p-6 pt-2 space-y-8">
+            <div>
+              <HorizontalBarChart year={year} />
+            </div>
+            <div>
+              <StreamChoiceGraph year={year} />
+            </div>
+            <div>
+              <GradeDistributionChart year={year} />
+            </div>
           </div>
-          <div>
-            <StreamChoiceGraph year={year} />
-          </div>
-          <div>
-            <GradeDistributionChart year={year} />
-          </div>
-        </div>
+        )}
       </div>
     </div>
   );
@@ -350,7 +359,7 @@ function DashboardContent() {
   useEffect(() => {
     async function initiatePage() {
       try {
-        const loggedInUser = await account.get();
+        const loggedInUser = await getAccountCached();
         if (!loggedInUser.emailVerification) {
           navigate("/authenticate");
           return;
@@ -360,11 +369,7 @@ function DashboardContent() {
         // ── Gating: check required data for each currently-open window ──
         let doc: Record<string, unknown> | null = null;
         try {
-          doc = (await database.getDocument(
-            DATABASE_ID,
-            COLL_USERS,
-            loggedInUser.$id
-          )) as unknown as Record<string, unknown>;
+          doc = (await getUserDocCached(loggedInUser.$id)) as unknown as Record<string, unknown>;
         } catch {
           // No user doc yet — redirect to /me whenever any window is open.
           const a = getCohortAccess(dashboardYear);
@@ -425,9 +430,9 @@ function DashboardContent() {
         if (showLiveChoiceProjection) {
           try {
             const [cutoffTotalDoc, marksTotalDoc, allCutoffs] = await Promise.all([
-              database.getDocument(DATABASE_ID, COLL_CUTOFFS, cutoffDocId(dashboardYear, "total")),
-              database.getDocument(DATABASE_ID, COLL_MARKS, markDocId(dashboardYear, "total")),
-              database.listDocuments(DATABASE_ID, COLL_CUTOFFS, queriesForCutoffYear(dashboardYear)),
+              getCutoffTotalCached(dashboardYear),
+              getMarksTotalCached(dashboardYear),
+              listCutoffsForYearCached(dashboardYear),
             ]);
 
             const first = Number(cutoffTotalDoc.firstChoice) || 0;

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import { AnalyticsWrapper } from "@/components/AnalyticsWrapper";
 import { ElectionBanner } from "@/components/ElectionBanner";
+import { QueryProvider } from "@/components/QueryProvider";
 import { TransitionProvider } from "@/components/TransitionProvider";
 import "./globals.css";
 
@@ -75,14 +76,16 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={`${inter.variable} font-sans antialiased`}>
-        <TransitionProvider>
-          <AnalyticsWrapper>
-            {/* <ElectionBanner /> */}
-            <main>
-              {children}
-            </main>
-          </AnalyticsWrapper>
-        </TransitionProvider>
+        <QueryProvider>
+          <TransitionProvider>
+            <AnalyticsWrapper>
+              {/* <ElectionBanner /> */}
+              <main>
+                {children}
+              </main>
+            </AnalyticsWrapper>
+          </TransitionProvider>
+        </QueryProvider>
       </body>
     </html>
   );

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -7,6 +7,7 @@ import GridBackground from "@/components/GridBackground";
 import HomeButton from "@/components/HomeButton";
 import { useSectionTracking } from "@/hooks/useSectionTracking"
 import { usePageTransition } from "@/components/TransitionProvider";
+import { getAccountCached } from "@/lib/appwriteCache";
 
 function LoginContent() {
   const [email, setEmail] = useState("");
@@ -22,7 +23,7 @@ function LoginContent() {
   useEffect(() => {
     async function initiatePage() {
         try {
-            await account.get();
+            await getAccountCached();
             navigate('/dashboard');
         }
         catch (error) {

--- a/frontend/app/me/page.tsx
+++ b/frontend/app/me/page.tsx
@@ -11,8 +11,8 @@ import Combobox from "@/components/Combobox";
 import ComboboxStreams from "@/components/ComboboxStream";
 import LogoutButton from "@/components/LogoutButton";
 import { Checkbox } from "@/components/ui/checkbox";
-import { account, database } from "../appwrite";
-import { ADMISSION, COLL_USERS, DATABASE_ID } from "@/lib/appwriteDb";
+import { ADMISSION } from "@/lib/appwriteDb";
+import { getAccountCached, getUserDocCached } from "@/lib/appwriteCache";
 import TextField from "@/components/TextField";
 import { useSectionTracking } from "@/hooks/useSectionTracking";
 import { getCohortAccess } from "@/lib/scheduleConfig";
@@ -190,7 +190,7 @@ export default function MePage() {
     let cancelled = false;
     async function load() {
       try {
-        const loggedInUser = await account.get();
+        const loggedInUser = await getAccountCached();
         if (!loggedInUser.emailVerification) {
           navigate("/authenticate");
           return;
@@ -199,11 +199,7 @@ export default function MePage() {
         let ay = ADMISSION.current;
         let hasDoc = false;
         try {
-          const doc = await database.getDocument(
-            DATABASE_ID,
-            COLL_USERS,
-            loggedInUser.$id
-          );
+          const doc = await getUserDocCached(loggedInUser.$id);
           hasDoc = true;
           const d = doc as Record<string, unknown>;
           ay = Number(d.admitYear) || ADMISSION.current;

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -17,7 +17,7 @@ import LiveCounter from "@/components/LiveCounter";
 
 import { useSectionTracking } from "@/hooks/useSectionTracking";
 import { usePageTransition } from "@/components/TransitionProvider";
-import { account } from "./appwrite";
+import { getAccountCached } from "@/lib/appwriteCache";
 
 function HomeContent() {
   const sectionRef = useSectionTracking("Home");
@@ -27,7 +27,7 @@ function HomeContent() {
   useEffect(() => {
     async function checkSession() {
       try {
-        await account.get();
+        await getAccountCached();
         setLoggedIn(true);
       } catch {
         /* not logged in */

--- a/frontend/app/sign-up/page.tsx
+++ b/frontend/app/sign-up/page.tsx
@@ -5,6 +5,7 @@ import { usePageTransition } from "@/components/TransitionProvider";
 import { account, database, ID } from "../appwrite";
 import { Permission, Role } from "appwrite";
 import { COLL_USERS, DATABASE_ID } from "@/lib/appwriteDb";
+import { getAccountCached } from "@/lib/appwriteCache";
 import Link from "next/link";
 import GridBackground from "@/components/GridBackground";
 import HomeButton from "@/components/HomeButton";
@@ -49,7 +50,7 @@ function SignUpContent() {
   useEffect(() => {
     async function initiatePage() {
       try {
-        await account.get();
+        await getAccountCached();
         if (!isSigningUp) {
           navigate("/dashboard");
         }

--- a/frontend/app/stats/page.tsx
+++ b/frontend/app/stats/page.tsx
@@ -12,12 +12,10 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from "recharts";
-import { Query } from "appwrite";
 import GridBackground from "@/components/GridBackground";
 import HomeButton from "@/components/HomeButton";
 import Footer from "@/components/Footer";
-import { database } from "../appwrite";
-import { DATABASE_ID, COLL_TRAFFIC } from "@/lib/appwriteDb";
+import { listTrafficDocsCached } from "@/lib/appwriteCache";
 import { useSectionTracking } from "@/hooks/useSectionTracking";
 import {
   addDaysUtc,
@@ -740,9 +738,7 @@ export default function StatsPage() {
   useEffect(() => {
     async function load() {
       try {
-        const res = await database.listDocuments(DATABASE_ID, COLL_TRAFFIC, [
-          Query.limit(120),
-        ]);
+        const res = await listTrafficDocsCached(120);
         const docs = res.documents as unknown as TrafficMonthDoc[];
         setDailyAll(expandDocsToDaily(docs, yesterday));
       } catch (e) {

--- a/frontend/components/Footer.tsx
+++ b/frontend/components/Footer.tsx
@@ -3,7 +3,7 @@
 import { Link as LinkIcon } from "lucide-react";
 import Link from "next/link";
 import { useEffect, useState } from "react";
-import { account } from "../app/appwrite";
+import { getAccountCached } from "@/lib/appwriteCache";
 
 export default function Footer() {
   const currentYear = new Date().getFullYear();
@@ -13,7 +13,7 @@ export default function Footer() {
     let cancelled = false;
     async function check() {
       try {
-        await account.get();
+        await getAccountCached();
         if (!cancelled) setLoggedIn(true);
       } catch {
         if (!cancelled) setLoggedIn(false);

--- a/frontend/components/GradeDistributionChart.tsx
+++ b/frontend/components/GradeDistributionChart.tsx
@@ -33,14 +33,11 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { ChartConfig, ChartContainer } from "@/components/ui/chart";
-import { database } from "../app/appwrite";
 import {
   ADMISSION,
-  DATABASE_ID,
-  COLL_MARKS,
-  markDocId,
   academicYearFullLabel,
 } from "@/lib/appwriteDb";
+import { getMarksCourseCached } from "@/lib/appwriteCache";
 import { getCohortAccess } from "@/lib/scheduleConfig";
 import { useState, useEffect, useRef, useMemo } from "react";
 import { cn } from "@/lib/utils";
@@ -80,11 +77,7 @@ const initialChartData = Array.from({ length: 12 }, (_, i) => ({
 
 async function fetchDistribution(year: number, course: string) {
   try {
-    const document = await database.getDocument(
-      DATABASE_ID,
-      COLL_MARKS,
-      markDocId(year, course)
-    );
+    const document = await getMarksCourseCached(year, course);
     const grades = document.distribution.split(",").map(Number);
     grades.push(Number(document.average));
     return grades;

--- a/frontend/components/HorizontalBarChart.tsx
+++ b/frontend/components/HorizontalBarChart.tsx
@@ -14,21 +14,20 @@ import {
   Cell,
   Tooltip as ChartTooltip,
 } from "recharts";
-import { account, database } from "../app/appwrite";
 import {
   ADMISSION,
-  COLL_USERS,
-  DATABASE_ID,
-  COLL_CUTOFFS,
-  COLL_MARKS,
   isActiveEng1Cohort,
   isGraduatedCohort,
-  listCutoffsForYear,
   streamKeyFromCutoffDocId,
-  cutoffDocId,
-  markDocId,
   academicYearFullLabel,
 } from "@/lib/appwriteDb";
+import {
+  getAccountCached,
+  getCutoffTotalCached,
+  getMarksTotalCached,
+  getUserDocCached,
+  listCutoffsForYearCached,
+} from "@/lib/appwriteCache";
 import { getCohortAccess } from "@/lib/scheduleConfig";
 import { CardDescription } from "@/components/ui/card";
 import {
@@ -186,13 +185,9 @@ export default function HorizontalBarChart({
       let ugpa = 4;
 
       try {
-        const loggedInUser = await account.get();
+        const loggedInUser = await getAccountCached();
         try {
-          const user = await database.getDocument(
-            DATABASE_ID,
-            COLL_USERS,
-            loggedInUser.$id
-          );
+          const user = await getUserDocCached(loggedInUser.$id);
           const ay = (user as { admitYear?: number }).admitYear;
           ugpa = Number((user as { gpa?: number }).gpa) || 0;
           const acc = getCohortAccess(year);
@@ -211,7 +206,8 @@ export default function HorizontalBarChart({
           return;
         }
 
-        const cutoffDocs = await listCutoffsForYear(database, year);
+        const cutoffDocsRes = await listCutoffsForYearCached(year);
+        const cutoffDocs = cutoffDocsRes.documents;
         cutoffDocs.forEach(
           (doc: {
             $id: string;
@@ -233,26 +229,14 @@ export default function HorizontalBarChart({
 
         try {
           if (getCohortAccess(year).showReportedCutoffs) {
-            const totalDoc = await database.getDocument(
-              DATABASE_ID,
-              COLL_CUTOFFS,
-              cutoffDocId(year, "total")
-            );
-            setTotalContributions(Number(totalDoc.streamCount) || 0);
-            setTotalFreeChoiceContributions(Number(totalDoc.freeChoice) || 0);
-            setTotalReported(Number(totalDoc.reportCutoff) || 0);
+            const totalCached = await getCutoffTotalCached(year);
+            setTotalContributions(Number(totalCached.streamCount) || 0);
+            setTotalFreeChoiceContributions(Number(totalCached.freeChoice) || 0);
+            setTotalReported(Number(totalCached.reportCutoff) || 0);
           } else {
             const [marksTotal, cutoffTotal] = await Promise.all([
-              database.getDocument(
-                DATABASE_ID,
-                COLL_MARKS,
-                markDocId(year, "total")
-              ),
-              database.getDocument(
-                DATABASE_ID,
-                COLL_CUTOFFS,
-                cutoffDocId(year, "total")
-              ),
+              getMarksTotalCached(year),
+              getCutoffTotalCached(year),
             ]);
             const distributionStr = marksTotal.distribution || "";
             const distributionArr = distributionStr

--- a/frontend/components/HorizontalBarChartGrades.tsx
+++ b/frontend/components/HorizontalBarChartGrades.tsx
@@ -2,16 +2,14 @@
 
 import { useState, useEffect } from "react";
 import { Bar, BarChart, CartesianGrid, ReferenceLine, XAxis, YAxis, Label, ResponsiveContainer, Cell, Tooltip as ChartTooltip } from "recharts";
-import { database } from "../app/appwrite";
-import { Query } from "appwrite";
 import {
   ADMISSION,
-  DATABASE_ID,
-  COLL_MARKS,
-  COLL_CUTOFFS,
   markDocId,
-  cutoffDocId,
 } from "@/lib/appwriteDb";
+import {
+  getCutoffTotalCached,
+  getMarksCourseCached,
+} from "@/lib/appwriteCache";
 import { CardDescription } from "@/components/ui/card";
 
 import {
@@ -49,32 +47,25 @@ const MARK_COURSE_IDS = [
 
 async function initPage() {
   try {
-    const markIds = MARK_COURSE_IDS.map((c) => markDocId(ADMISSION.current, c));
-    let documents = await database.listDocuments(DATABASE_ID, COLL_MARKS, [
-      Query.equal("$id", markIds),
-    ]);
+    const documents = await Promise.all(
+      MARK_COURSE_IDS.map((course) => getMarksCourseCached(ADMISSION.current, course))
+    );
 
-    documents.documents.forEach((doc) => {
-      const baseId = doc.$id.replace(/^\d+_/, "");
+    documents.forEach((doc) => {
+      const baseId = String(doc.$id || markDocId(ADMISSION.current, "math1za3")).replace(/^\d+_/, "");
       if (baseId === "math1za3") {
         courseData[0].average = parseFloat(String(doc.average || "0"));
-      }
-      if (baseId === "math1zb3") {
+      } else if (baseId === "math1zb3") {
         courseData[1].average = parseFloat(String(doc.average || "0"));
-      }
-      if (baseId === "math1zc3") {
+      } else if (baseId === "math1zc3") {
         courseData[2].average = parseFloat(String(doc.average || "0"));
-      }
-      if (baseId === "phys1d03") {
+      } else if (baseId === "phys1d03") {
         courseData[3].average = parseFloat(String(doc.average || "0"));
-      }
-      if (baseId === "phys1e03") {
+      } else if (baseId === "phys1e03") {
         courseData[4].average = parseFloat(String(doc.average || "0"));
-      }
-      if (baseId === "chem1e03") {
+      } else if (baseId === "chem1e03") {
         courseData[5].average = parseFloat(String(doc.average || "0"));
-      }
-      if (baseId === "eng1p13") {
+      } else if (baseId === "eng1p13") {
         courseData[6].average = parseFloat(String(doc.average || "0"));
       }
     });
@@ -153,11 +144,7 @@ export default function CourseGradeChart() {
 
       // Fetch contribution count
       try {
-        const contributions = await database.getDocument(
-          DATABASE_ID,
-          COLL_CUTOFFS,
-          cutoffDocId(ADMISSION.current, "total")
-        );
+        const contributions = await getCutoffTotalCached(ADMISSION.current);
         setTotalContributions(contributions.streamCount);
       } catch (error) {
         console.error("Error fetching contribution count:", error);

--- a/frontend/components/LiveCounter.tsx
+++ b/frontend/components/LiveCounter.tsx
@@ -2,16 +2,11 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { animate, motion, AnimatePresence } from "framer-motion";
-import { Query } from "appwrite";
 import { TrendingDown, TrendingUp } from "lucide-react";
-import { database } from "./../app/appwrite";
 import {
   ADMISSION,
-  DATABASE_ID,
-  COLL_CUTOFFS,
-  COLL_TRAFFIC,
-  cutoffDocId,
 } from "@/lib/appwriteDb";
+import { getCutoffTotalCached, listTrafficDocsCached } from "@/lib/appwriteCache";
 import { COHORT_LAUNCH_YEAR } from "@/lib/scheduleConfig";
 import {
   addDaysUtc,
@@ -71,9 +66,7 @@ export default function LiveCounter({
       const years: number[] = [];
       for (let y = COHORT_LAUNCH_YEAR; y <= ADMISSION.current; y++) years.push(y);
       const totals = await Promise.all(
-        years.map((year) =>
-          database.getDocument(DATABASE_ID, COLL_CUTOFFS, cutoffDocId(year, "total"))
-        )
+        years.map((year) => getCutoffTotalCached(year))
       );
       const contributions = totals.reduce((sum, totalDoc, idx) => {
         const year = years[idx];
@@ -95,9 +88,7 @@ export default function LiveCounter({
       setViews7d(null);
       setWowInfo(null);
       try {
-        const res = await database.listDocuments(DATABASE_ID, COLL_TRAFFIC, [
-          Query.limit(120),
-        ]);
+        const res = await listTrafficDocsCached(120);
         const docs = res.documents as unknown as TrafficMonthDoc[];
         const daily = expandDocsToDaily(docs, lastTrafficDay);
         const map = dailyToMap(daily);

--- a/frontend/components/QueryProvider.tsx
+++ b/frontend/components/QueryProvider.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { QueryClientProvider } from "@tanstack/react-query";
+import { queryClient } from "@/lib/queryClient";
+
+export function QueryProvider({ children }: { children: React.ReactNode }) {
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/frontend/components/StreamChoiceGraph.tsx
+++ b/frontend/components/StreamChoiceGraph.tsx
@@ -2,15 +2,12 @@
 
 import { useState, useEffect, useMemo } from "react";
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis, ResponsiveContainer, Tooltip as ChartTooltip } from "recharts";
-import { database } from "../app/appwrite";
 import {
   ADMISSION,
-  DATABASE_ID,
-  COLL_CUTOFFS,
-  queriesForCutoffYear,
   streamKeyFromCutoffDocId,
   academicYearFullLabel,
 } from "@/lib/appwriteDb";
+import { listCutoffsForYearCached } from "@/lib/appwriteCache";
 import { getCohortAccess } from "@/lib/scheduleConfig";
 import {
   Card,
@@ -59,7 +56,7 @@ const CustomTooltip = ({ active, payload }: { active?: boolean; payload?: { payl
 
 async function fetchStreamChoiceData(year: number) {
   try {
-    const documents = await database.listDocuments(DATABASE_ID, COLL_CUTOFFS, queriesForCutoffYear(year));
+    const documents = await listCutoffsForYearCached(year);
     const updatedChartData = [...initialChartData];
     let totalSubmissions = 0;
 

--- a/frontend/lib/appwriteCache.ts
+++ b/frontend/lib/appwriteCache.ts
@@ -1,0 +1,77 @@
+"use client";
+
+import { account, database } from "@/app/appwrite";
+import { Query } from "appwrite";
+import {
+  COLL_CUTOFFS,
+  COLL_MARKS,
+  COLL_TRAFFIC,
+  COLL_USERS,
+  DATABASE_ID,
+  cutoffDocId,
+  markDocId,
+  queriesForCutoffYear,
+} from "@/lib/appwriteDb";
+import { queryClient } from "@/lib/queryClient";
+
+const SHORT_STALE_MS = 30_000;
+const DEFAULT_STALE_MS = 60_000;
+
+export async function getAccountCached() {
+  return queryClient.fetchQuery({
+    queryKey: ["account", "current"],
+    queryFn: async () => account.get(),
+    staleTime: SHORT_STALE_MS,
+  });
+}
+
+export async function getUserDocCached(userId: string) {
+  return queryClient.fetchQuery({
+    queryKey: ["users", userId],
+    queryFn: async () => database.getDocument(DATABASE_ID, COLL_USERS, userId),
+    staleTime: SHORT_STALE_MS,
+  });
+}
+
+export async function listCutoffsForYearCached(year: number) {
+  return queryClient.fetchQuery({
+    queryKey: ["cutoffs", year, "list"],
+    queryFn: async () =>
+      database.listDocuments(DATABASE_ID, COLL_CUTOFFS, queriesForCutoffYear(year)),
+    staleTime: DEFAULT_STALE_MS,
+  });
+}
+
+export async function getCutoffTotalCached(year: number) {
+  return queryClient.fetchQuery({
+    queryKey: ["cutoffs", year, "total"],
+    queryFn: async () =>
+      database.getDocument(DATABASE_ID, COLL_CUTOFFS, cutoffDocId(year, "total")),
+    staleTime: DEFAULT_STALE_MS,
+  });
+}
+
+export async function getMarksTotalCached(year: number) {
+  return queryClient.fetchQuery({
+    queryKey: ["marks", year, "total"],
+    queryFn: async () => database.getDocument(DATABASE_ID, COLL_MARKS, markDocId(year, "total")),
+    staleTime: DEFAULT_STALE_MS,
+  });
+}
+
+export async function getMarksCourseCached(year: number, course: string) {
+  return queryClient.fetchQuery({
+    queryKey: ["marks", year, course],
+    queryFn: async () => database.getDocument(DATABASE_ID, COLL_MARKS, markDocId(year, course)),
+    staleTime: DEFAULT_STALE_MS,
+  });
+}
+
+export async function listTrafficDocsCached(limit = 120) {
+  return queryClient.fetchQuery({
+    queryKey: ["traffic", "list", limit],
+    queryFn: async () =>
+      database.listDocuments(DATABASE_ID, COLL_TRAFFIC, [Query.limit(limit)]),
+    staleTime: SHORT_STALE_MS,
+  });
+}

--- a/frontend/lib/queryClient.ts
+++ b/frontend/lib/queryClient.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import { QueryClient } from "@tanstack/react-query";
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 60_000,
+      gcTime: 15 * 60_000,
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+  },
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "@radix-ui/react-slot": "^1.1.2",
         "@radix-ui/react-tabs": "^1.1.9",
         "@radix-ui/react-tooltip": "^1.1.8",
+        "@tanstack/react-query": "^5.100.7",
         "appwrite": "^14.0.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -2989,6 +2990,32 @@
         "@tailwindcss/oxide": "4.2.2",
         "postcss": "^8.5.6",
         "tailwindcss": "4.2.2"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.100.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.7.tgz",
+      "integrity": "sha512-5R7i6ENJLhVeeJrrUz7jKBXUXv/BJrxf9FQJSkR13bPrb3zOcE8A0Z0PxYCcsKPOsiIlTibrBL/zZbtUO1TFyQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.100.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.7.tgz",
+      "integrity": "sha512-LoISYWz8dOOuQbeIctF8K6yi42TWtR1WPGpwGuRUpF3u79JVVIg/PVR0MQdIA0VSHqD/ydf/b7PhKTkg3I4fLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@types/d3-array": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-tabs": "^1.1.9",
     "@radix-ui/react-tooltip": "^1.1.8",
+    "@tanstack/react-query": "^5.100.7",
     "appwrite": "^14.0.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Part 1 — Shared frontend cache layer (React Query)

### Motivation

Frontend pages/components were fetching the same Appwrite documents independently (often concurrently), causing duplicate network calls, slower loads, and unnecessary backend read pressure.

This change introduces a shared in-memory query cache and standardized read helpers so identical requests are deduplicated automatically.

### Core architecture

| Layer | File(s) | Responsibility |
|------|---------|----------------|
| **Query client config** | `frontend/lib/queryClient.ts` | Global cache behavior (`staleTime`, `gcTime`, retry, focus refetch policy) |
| **React provider** | `frontend/components/QueryProvider.tsx` | Injects query client into app tree |
| **App root wiring** | `frontend/app/layout.tsx` | Wraps app with `QueryProvider` |
| **Cached Appwrite read API** | `frontend/lib/appwriteCache.ts` | Canonical read helpers using `queryClient.fetchQuery(...)` |

### Query defaults

| Option | Value | Effect |
|-------|-------|--------|
| `staleTime` | `60_000` | Data treated fresh for 60s (fewer immediate refetches) |
| `gcTime` | `15 * 60_000` | Unused cache retained for 15m before eviction |
| `retry` | `1` | One retry on transient failure |
| `refetchOnWindowFocus` | `false` | No auto refetch when tab regains focus |

### Cached helpers added

| Helper | Query key shape | Backing Appwrite read |
|--------|------------------|------------------------|
| `getAccountCached()` | `["account","current"]` | `account.get()` |
| `getUserDocCached(userId)` | `["users", userId]` | `getDocument(users, userId)` |
| `listCutoffsForYearCached(year)` | `["cutoffs", year, "list"]` | `listDocuments(cutoffs, queriesForCutoffYear(year))` |
| `getCutoffTotalCached(year)` | `["cutoffs", year, "total"]` | `getDocument(cutoffs, "{year}_total")` |
| `getMarksTotalCached(year)` | `["marks", year, "total"]` | `getDocument(marks, "{year}_total")` |
| `getMarksCourseCached(year, course)` | `["marks", year, course]` | `getDocument(marks, "{year}_{course}")` |
| `listTrafficDocsCached(limit)` | `["traffic","list",limit]` | `listDocuments(traffic, Query.limit(limit))` |

---

## Part 2 — Dashboard + chart dedupe migration

### Scope

Dashboard flow and chart components were migrated first so the heaviest duplicate-read paths are cache-backed.

### Files updated

| File | Change |
|------|--------|
| `frontend/app/dashboard/page.tsx` | Replaced direct account/user/cutoff/marks list reads with cache helpers |
| `frontend/components/HorizontalBarChart.tsx` | Uses cached account/user/cutoffs/marks total reads |
| `frontend/components/StreamChoiceGraph.tsx` | Uses cached yearly cutoffs list |
| `frontend/components/GradeDistributionChart.tsx` | Uses cached marks-per-course reads |

### Behavior impact

- Concurrent reads for same year/doc now collapse to one in-flight request.
- Reopening dashboard views reuses warm cache instead of issuing fresh duplicate reads.
- Existing UI logic and schedule gating remain unchanged.

---

## Part 3 — Site-wide read migration

### Scope

Remaining frontend read paths were migrated to the same cache helpers for consistent dedupe across the app.

### Files updated

| File | Change |
|------|--------|
| `frontend/components/LiveCounter.tsx` | Cached cutoff totals + cached traffic list |
| `frontend/app/stats/page.tsx` | Cached traffic list |
| `frontend/app/me/page.tsx` | Cached account + user doc fetch |
| `frontend/app/page.tsx` | Cached session check |
| `frontend/app/login/page.tsx` | Cached session check |
| `frontend/app/sign-up/page.tsx` | Cached session check |
| `frontend/app/authenticate/page.tsx` | Cached account read |
| `frontend/app/contact/page.tsx` | Cached account read |
| `frontend/components/Footer.tsx` | Cached account read for logged-in gate |
| `frontend/components/HorizontalBarChartGrades.tsx` | Cached marks course docs + cutoff total |
| `frontend/actions/logActions.ts` | Cached account/user reads on profile save/read-merge path |

### Notes

- Write operations (`createDocument`, `updateDocument`, auth mutations) are intentionally unchanged.
- `frontend/lib/appwriteDb.ts` helper internals remain available; high-traffic read paths now route through `appwriteCache`.

---

## Result

### What this delivers

- Shared, centralized frontend caching behavior
- Automatic dedupe of repeated and concurrent reads
- Lower Appwrite read volume
- Better perceived responsiveness on dashboard/stats/auth-gated flows

### Dependency changes

- Added: `@tanstack/react-query` in `frontend/package.json` / lockfile.